### PR TITLE
Removed packages

### DIFF
--- a/roles/package-install/vars/main.yml
+++ b/roles/package-install/vars/main.yml
@@ -2,7 +2,6 @@
 packages:
   - awscli
   - azure-cli
-  - bloodhound
   - cmake
   - covenant-kbx
   - curl
@@ -12,7 +11,6 @@ packages:
   - exa
   - exif
   - exiftool
-  - eyewitness
   - ffuf
   - flameshot
   - gdb


### PR DESCRIPTION
Removed Bloodhoud because it will be installed via pip and the apt repository doesn't have a arm version of the package.
Eyewitness also doesn't have a arm package and I rarely use it anyway. 